### PR TITLE
smarter dupe check and file trimming

### DIFF
--- a/data/bse/functions/search/cmd/found_spawner.mcfunction
+++ b/data/bse/functions/search/cmd/found_spawner.mcfunction
@@ -1,7 +1,0 @@
-execute as @e[type=item,limit=1,sort=nearest] run function bse:search/cmd/found_spawner/item
-setblock ~ ~ ~ spawner
-data modify block ~ ~ ~ {} merge from storage bse:search current
-
-function bse:use_tool/found_spawner
-
-kill @e[type=minecraft:experience_orb]

--- a/data/bse/functions/search/cmd/found_spawner/item.mcfunction
+++ b/data/bse/functions/search/cmd/found_spawner/item.mcfunction
@@ -1,2 +1,0 @@
-data modify storage bse:search current set from entity @s Item.tag.spawner
-kill @s

--- a/data/bse/functions/uninstall.mcfunction
+++ b/data/bse/functions/uninstall.mcfunction
@@ -12,7 +12,9 @@ data remove storage bse:main current
 data remove storage bse:main spawners
 data remove storage bse:backup version
 data remove storage bse:backup spawners
-data remove storage bse:search current
+data remove storage bse:fix_tag current
+data remove storage bse:fix_tag potentials_in
+data remove storage bse:fix_tag potentials_out
 
 #clearing slow loop
 schedule clear bse:slow_loop

--- a/data/bse/functions/use_tool/create_new.mcfunction
+++ b/data/bse/functions/use_tool/create_new.mcfunction
@@ -1,10 +1,11 @@
-#adding selected spawner to current and removing extraneous data
+#adding selected spawner to current and removing extraneous data/fixing item data
 data modify storage bse:main current set from block ~ ~ ~
 data remove storage bse:main current.x
 data remove storage bse:main current.y
 data remove storage bse:main current.z
 data remove storage bse:main current.id
 data remove storage bse:main current.Delay
+function bse:use_tool/create_new/fix_tag
 
 #searching for duplicate values
 execute if data storage bse:main spawners[0] run function bse:util/find_dupe

--- a/data/bse/functions/use_tool/create_new/fix_tag.mcfunction
+++ b/data/bse/functions/use_tool/create_new/fix_tag.mcfunction
@@ -1,0 +1,10 @@
+#fixing SpawnData object
+data modify storage bse:fix_tag current set from storage bse:main current.SpawnData
+function bse:use_tool/create_new/fix_tag/fix_current_entity
+data modify storage bse:main current.SpawnData set from storage bse:fix_tag current
+
+#fixing spawn potentials array
+data modify storage bse:fix_tag potentials_in set from storage bse:main current.SpawnPotentials
+data modify storage bse:fix_tag potentials_out set value []
+function bse:use_tool/create_new/fix_tag/spawn_potentials
+data modify storage bse:main current.SpawnPotentials set from storage bse:fix_tag potentials_out

--- a/data/bse/functions/use_tool/create_new/fix_tag/armor_items/0.mcfunction
+++ b/data/bse/functions/use_tool/create_new/fix_tag/armor_items/0.mcfunction
@@ -1,0 +1,4 @@
+#removing, and re-writing the tag object
+data modify storage bse:fix_tag temp set from storage bse:fix_tag current.ArmorItems[0].tag
+data remove storage bse:fix_tag current.ArmorItems[0].tag
+data modify storage bse:fix_tag current.ArmorItems[0].tag set from storage bse:fix_tag temp

--- a/data/bse/functions/use_tool/create_new/fix_tag/armor_items/1.mcfunction
+++ b/data/bse/functions/use_tool/create_new/fix_tag/armor_items/1.mcfunction
@@ -1,0 +1,4 @@
+#removing, and re-writing the tag object
+data modify storage bse:fix_tag temp set from storage bse:fix_tag current.ArmorItems[1].tag
+data remove storage bse:fix_tag current.ArmorItems[1].tag
+data modify storage bse:fix_tag current.ArmorItems[1].tag set from storage bse:fix_tag temp

--- a/data/bse/functions/use_tool/create_new/fix_tag/armor_items/2.mcfunction
+++ b/data/bse/functions/use_tool/create_new/fix_tag/armor_items/2.mcfunction
@@ -1,0 +1,4 @@
+#removing, and re-writing the tag object
+data modify storage bse:fix_tag temp set from storage bse:fix_tag current.ArmorItems[2].tag
+data remove storage bse:fix_tag current.ArmorItems[2].tag
+data modify storage bse:fix_tag current.ArmorItems[2].tag set from storage bse:fix_tag temp

--- a/data/bse/functions/use_tool/create_new/fix_tag/armor_items/3.mcfunction
+++ b/data/bse/functions/use_tool/create_new/fix_tag/armor_items/3.mcfunction
@@ -1,0 +1,4 @@
+#removing, and re-writing the tag object
+data modify storage bse:fix_tag temp set from storage bse:fix_tag current.ArmorItems[3].tag
+data remove storage bse:fix_tag current.ArmorItems[3].tag
+data modify storage bse:fix_tag current.ArmorItems[3].tag set from storage bse:fix_tag temp

--- a/data/bse/functions/use_tool/create_new/fix_tag/fix_current_entity.mcfunction
+++ b/data/bse/functions/use_tool/create_new/fix_tag/fix_current_entity.mcfunction
@@ -1,0 +1,9 @@
+#doing weird branching here to save on command load since this is run often
+#HandItems
+execute if data storage bse:fix_tag current.HandItems[0].tag run function bse:use_tool/create_new/fix_tag/hand_items/0
+execute if data storage bse:fix_tag current.HandItems[1].tag run function bse:use_tool/create_new/fix_tag/hand_items/1
+#ArmorItems
+execute if data storage bse:fix_tag current.ArmorItems[0].tag run function bse:use_tool/create_new/fix_tag/armor_items/0
+execute if data storage bse:fix_tag current.ArmorItems[1].tag run function bse:use_tool/create_new/fix_tag/armor_items/1
+execute if data storage bse:fix_tag current.ArmorItems[2].tag run function bse:use_tool/create_new/fix_tag/armor_items/2
+execute if data storage bse:fix_tag current.ArmorItems[3].tag run function bse:use_tool/create_new/fix_tag/armor_items/3

--- a/data/bse/functions/use_tool/create_new/fix_tag/hand_items/0.mcfunction
+++ b/data/bse/functions/use_tool/create_new/fix_tag/hand_items/0.mcfunction
@@ -1,0 +1,4 @@
+#removing, and re-writing the tag object
+data modify storage bse:fix_tag temp set from storage bse:fix_tag current.HandItems[0].tag
+data remove storage bse:fix_tag current.HandItems[0].tag
+data modify storage bse:fix_tag current.HandItems[0].tag set from storage bse:fix_tag temp

--- a/data/bse/functions/use_tool/create_new/fix_tag/hand_items/1.mcfunction
+++ b/data/bse/functions/use_tool/create_new/fix_tag/hand_items/1.mcfunction
@@ -1,0 +1,4 @@
+#removing, and re-writing the tag object
+data modify storage bse:fix_tag temp set from storage bse:fix_tag current.HandItems[1].tag
+data remove storage bse:fix_tag current.HandItems[1].tag
+data modify storage bse:fix_tag current.HandItems[1].tag set from storage bse:fix_tag temp

--- a/data/bse/functions/use_tool/create_new/fix_tag/spawn_potentials.mcfunction
+++ b/data/bse/functions/use_tool/create_new/fix_tag/spawn_potentials.mcfunction
@@ -1,0 +1,11 @@
+#recursively fixing spawn potentials entities
+#moving into current
+data modify storage bse:fix_tag current set from storage bse:fix_tag potentials_in[0].Entity
+data modify storage bse:fix_tag potentials_out append from storage bse:fix_tag potentials_in[0]
+data remove storage bse:fix_tag potentials_in[0]
+#fixing tags
+function bse:use_tool/create_new/fix_tag/fix_current_entity
+#writing into output array
+data modify storage bse:fix_tag potentials_out[-1].Entity set from storage bse:fix_tag current
+#loop
+execute if data storage bse:fix_tag potentials_in[0] run function bse:use_tool/create_new/fix_tag/spawn_potentials


### PR DESCRIPTION
If the user f3+i's a spawner and inports it into MCStacker, edits it, then exports back into a command, it was possible that some spawners would have non-matching data even though the contents was identical. This is likley due to MC stacker inverting the order that the Count byte and the tag object of an item. To fix this I manually remove and re-add the tag object of each item on an entity in the hands and armor.